### PR TITLE
修复OC的EFI中，键盘上command 和 option 按键错位的问题

### DIFF
--- a/EFI_OC/OC/Kexts/VoodooPS2Controller.kext/Contents/PlugIns/VoodooPS2Keyboard.kext/Contents/Info.plist
+++ b/EFI_OC/OC/Kexts/VoodooPS2Controller.kext/Contents/PlugIns/VoodooPS2Keyboard.kext/Contents/Info.plist
@@ -304,7 +304,7 @@
 					<key>Swap capslock and left control</key>
 					<false/>
 					<key>Swap command and option</key>
-					<true/>
+					<false/>
 					<key>Use ISO layout keyboard</key>
 					<false/>
 					<key>alt_handler_id</key>


### PR DESCRIPTION
在Clover版本中是没有这个问题的，但是OC的 EFI中这两个按键是反过来的。